### PR TITLE
Update livedb-mongo to 0.2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "derby": "0.5.x",
     "express": "~3.2.5",
     "redis": "~0.8.3",
-    "livedb-mongo": "~0.1.0",
+    "livedb-mongo": "~0.2",
     "racer-browserchannel": "~0.1.0",
     "connect-mongo": "~0.3.2",
     "marked": "0.2.9"


### PR DESCRIPTION
There's an issue with current DerbyJS, and livedb-mongo 0.1.x.

It returns an error:

```
Error: Missing or invalid snapshot db
```

The fix is to upgrade livedb-mongo to the latest version.
