### PR TITLE
Add check for empty document.

### DIFF
--- a/lib/app/index.js
+++ b/lib/app/index.js
@@ -18,6 +18,11 @@ app.get('/document/:id', function (page, model, params, next) {
     document.subscribe(function (err) {
         if (err) return next(err);
 
+        // Make sure the document isn't empty
+        if (document.get('markdown') == undefined) {
+            return page.redirect('/', 404)
+        }
+
         // Create references that can be used in templates or controller methods
         model.ref('_page.document', document);
 


### PR DESCRIPTION
When accessing an empty page, it shows an error.

This will respond 404 to the request.
